### PR TITLE
FIX Some errors after Linux 5.6.

### DIFF
--- a/trace_irqoff.c
+++ b/trace_irqoff.c
@@ -202,11 +202,9 @@ static void stack_trace_skip_hardirq_init(void)
 
 	ret = register_kprobe(&kp);
 	if (ret < 0) {
-		printk(KERN_INFO "register_kprobe failed, error:%d\n", ret);
 		return;
 	}
 
-	printk(KERN_INFO "kallsyms_lookup_name addr: %p\n", kp.addr);
 	kallsyms_lookup_name_fun = (void*)kp.addr;
 	unregister_kprobe(&kp);
 


### PR DESCRIPTION
There two problems:
1. Since commit d56c0d45f0e2 ("proc: decouple proc from VFS with
"struct proc_ops""), we can not use struct file_operations * as
proc_create()'s fourth param.

2. Since commit 0bd476e6c671 ("kallsyms: unexport kallsyms_lookup_name()
and kallsyms_on_each_symbol()"), the kallsyms_lookup_name() is
unexported, we must find an another way to lookup_symbols.

Signed-off-by: Hui Su <sh_def@163.com>